### PR TITLE
hotfix: document.querySelector returns null if there are no nodes are…

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -94,7 +94,7 @@ function addVeloxiDataAttributes(
 }
 
 function createSwapy(
-  root: Element,
+  root: Element | null,
   userConfig: Config = {} as Config
 ): SwapyApi {
   const config = { ...DEFAULT_CONFIG, ...userConfig }


### PR DESCRIPTION
Hey dude! First of all, i'd like to say I really like the library. Thanks for sharing it with the community.

## Context

With version `0.0.5`, TypeScript currently complains that the `document.querySelector` method inside the `createSwapy` does not always necessarily return an element: if there are no nodes found whatsoever, it will return `null`.

This PR fixes the type definition so that we don't need to `@ts-ignore` any of our uses of this library. Ideally it should probably be a patch `0.0.6` release.

## Screenshots


| before | after | 
| ----- | ---- |
| <img width="996" alt="image" src="https://github.com/user-attachments/assets/c96694e9-c4f0-4653-befb-9df7a8efe82f"> | <img width="611" alt="image" src="https://github.com/user-attachments/assets/6c5f7dd4-8629-4d7b-a15a-ddaba1306ab6"> | 

## GIF

Here's a GIF for good luck with the project 💟 

![](https://media4.giphy.com/media/7zrm2raPv2EPKTgplN/giphy.webp?cid=790b7611v7swyay1t9onppw9qkbfljz21nxmpsd9zkmd2hkx&ep=v1_gifs_search&rid=giphy.webp&ct=g)