### PR TITLE
fix(vue example): add type to template ref

### DIFF
--- a/examples/vue/App.vue
+++ b/examples/vue/App.vue
@@ -14,10 +14,10 @@ const DEFAULT = {
 }
 const slotItems: Record<string, 'a' | 'c' | 'd' | null> = localStorage.getItem('slotItem') ? JSON.parse(localStorage.getItem('slotItem')!) : DEFAULT
 
-const container = ref()
+const container = ref<HTMLDivElement | null>(null)
 
 onMounted(() => {
-  if (container) {
+  if (container.value) {
     const swapy = createSwapy(container.value)
     swapy.onSwap(({ data }) => {
       localStorage.setItem('slotItem', JSON.stringify(data.object))


### PR DESCRIPTION
## 1. Add type to template ref

The Vue documentation suggests the following:

> Template refs should be created with an explicit generic type argument and an initial value of `null`.

https://vuejs.org/guide/typescript/composition-api.html#typing-template-refs

## 2. Add `.value` to ref

```ts
if (container.value) { // `.value` is needed here to access the ref's value
  // ...
}
```