### PR TITLE
feat: Add missing type exports

### DIFF
--- a/dist/swapy.d.ts
+++ b/dist/swapy.d.ts
@@ -1,4 +1,4 @@
-export declare type AnimationType = 'dynamic' | 'spring' | 'none';
+declare type AnimationType = 'dynamic' | 'spring' | 'none';
 
 export declare type Config = {
     animation: AnimationType;
@@ -16,14 +16,14 @@ export declare type SlotItemMap = SwapEventArray;
 
 export declare type SwapCallback = (event: SwapEventData) => void;
 
-export declare type SwapData = RequireOnlyOne<SwapEventDataData, 'map' | 'array' | 'object'>;
+declare type SwapData = RequireOnlyOne<SwapEventDataData, 'map' | 'array' | 'object'>;
 
 export declare type SwapEventArray = Array<{
     slotId: string;
     itemId: string | null;
 }>;
 
-export declare interface SwapEventData {
+declare interface SwapEventData {
     data: SwapEventDataData;
 }
 

--- a/dist/swapy.d.ts
+++ b/dist/swapy.d.ts
@@ -1,6 +1,6 @@
-declare type AnimationType = 'dynamic' | 'spring' | 'none';
+export declare type AnimationType = 'dynamic' | 'spring' | 'none';
 
-declare type Config = {
+export declare type Config = {
     animation: AnimationType;
     continuousMode: boolean;
     manualSwap: boolean;
@@ -14,32 +14,32 @@ declare type RequireOnlyOne<T, Keys extends keyof T = keyof T> = Keys extends ke
 
 export declare type SlotItemMap = SwapEventArray;
 
-declare type SwapCallback = (event: SwapEventData) => void;
+export declare type SwapCallback = (event: SwapEventData) => void;
 
-declare type SwapData = RequireOnlyOne<SwapEventDataData, 'map' | 'array' | 'object'>;
+export declare type SwapData = RequireOnlyOne<SwapEventDataData, 'map' | 'array' | 'object'>;
 
-declare type SwapEventArray = Array<{
+export declare type SwapEventArray = Array<{
     slotId: string;
     itemId: string | null;
 }>;
 
-declare interface SwapEventData {
+export declare interface SwapEventData {
     data: SwapEventDataData;
 }
 
-declare interface SwapEventDataData {
+export declare interface SwapEventDataData {
     map: SwapEventMap;
     array: SwapEventArray;
     object: SwapEventObject;
 }
 
-declare type SwapEventMap = Map<string, string | null>;
+export declare type SwapEventMap = Map<string, string | null>;
 
-declare type SwapEventObject = Record<string, string | null>;
+export declare type SwapEventObject = Record<string, string | null>;
 
 export declare type Swapy = SwapyApi;
 
-declare interface SwapyApi {
+export declare interface SwapyApi {
     onSwap(callback: SwapCallback): void;
     enable(enabled: boolean): void;
     destroy(): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export { createSwapy, type Swapy, type SlotItemMap } from './instance'
+export { createSwapy, type Swapy, type SwapyApi, type SwapCallback, type Config, type SlotItemMap } from './instance'
+export { type SwapEventObject, type SwapEventMap, type SwapEventArray, type SwapEventDataData } from './veloxi-plugin/SwapyPlugin'

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -10,7 +10,7 @@ import {
   SwapyPluginApi
 } from './veloxi-plugin/SwapyPlugin'
 
-interface SwapyApi {
+export interface SwapyApi {
   onSwap(callback: SwapCallback): void
   enable(enabled: boolean): void
   destroy(): void
@@ -319,6 +319,6 @@ class SwapyInstance {
   }
 }
 
-type SwapCallback = (event: SwapEventData) => void
+export type SwapCallback = (event: SwapEventData) => void
 
 export { createSwapy }

--- a/src/veloxi-plugin/SwapyPlugin.ts
+++ b/src/veloxi-plugin/SwapyPlugin.ts
@@ -6,7 +6,7 @@ export type SwapEventArray = Array<{ slotId: string; itemId: string | null }>
 export type SwapEventMap = Map<string, string | null>
 export type SwapEventObject = Record<string, string | null>
 
-interface SwapEventDataData {
+export interface SwapEventDataData {
   map: SwapEventMap
   array: SwapEventArray
   object: SwapEventObject


### PR DESCRIPTION
- Fixes #62 

Exported any not yet exported user facing types. 

I also exported `SwapiApi` just cause that is what shows up in the function signature. I think this makes it less confusing... If we want to just export one or the other we could change the function signature to use `Swapy` instead? Let me know your thoughts! 

- [x] Build to dist